### PR TITLE
Changed separator for task rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ any .retain files are filtered out (but the containing directories are included)
 
 To package up a template, simply run
 
-    ./gradlew packageTemplate#<templateName>
+    ./gradlew packageTemplate-<templateName>
 
 The name of the project template comes from the containing directory. So the
 template directory structure in src/templates/ratpack-lite results in a template
 called 'ratpack-lite', which can be packaged with
 
-    ./gradlew packageTemplate#ratpack-lite
+    ./gradlew packageTemplate-ratpack-lite
 
 The project template archive will be created in the build directory with the
 name '<template name>-template-<version>.zip'. See the small section below on
@@ -99,7 +99,7 @@ You can also package all the templates in one fell swoop:
 Once a template is packaged up, you can publish it to a generic (non-Maven)
 BinTray repository by running
 
-    ./gradlew publish#<templateName>
+    ./gradlew publish-<templateName>
 
 This will initially fail, because the build does not know where to publish to.
 That's quickly fixed by adding a gradle.properties file in the root of this

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ task verifyProps << {
 /**
  * Generates tasks to package individual project templates into zip archives.
  */
-tasks.addRule("Pattern: packageTemplate#<proj>") { String taskName ->
-    def m = taskName =~ /packageTemplate#(\S+)/
+tasks.addRule("Pattern: packageTemplate-<proj>") { String taskName ->
+    def m = taskName =~ /packageTemplate-(\S+)/
     if (m) {
         def tmplName = m[0][1]
         def tmplDir = new File(templatesDir, tmplName)
@@ -98,13 +98,13 @@ tasks.addRule("Pattern: packageTemplate#<proj>") { String taskName ->
  * Packages all the project templates into zip archives.
  */
 def templateDirs = templatesDir.listFiles({ f -> f.directory} as FileFilter)
-task packageTemplates(dependsOn: templateDirs.collect { project.tasks["packageTemplate#${it.name}"] })
+task packageTemplates(dependsOn: templateDirs.collect { project.tasks["packageTemplate-${it.name}"] })
 
 /**
  * Generates tasks to publish individual project template archives to BinTray.
  */
-tasks.addRule("Pattern: publish#<proj>") { String taskName ->
-    def m = taskName =~ /publish#(\S+)/
+tasks.addRule("Pattern: publish-<proj>") { String taskName ->
+    def m = taskName =~ /publish-(\S+)/
     if (m) {
         def tmplName = m[0][1]
         def tmplDir = new File(templatesDir, tmplName)
@@ -117,7 +117,7 @@ tasks.addRule("Pattern: publish#<proj>") { String taskName ->
         def version = new File(tmplDir, "VERSION").text.trim()
         def archiveName = tmplName + "-template-" + version + ".zip"
 
-        task(taskName, type: BinTrayGenericUpload, dependsOn: ["verifyProps", "packageTemplate#$tmplName"]) {
+        task(taskName, type: BinTrayGenericUpload, dependsOn: ["verifyProps", "packageTemplate-$tmplName"]) {
             artifactFile = new File(project.buildDir, archiveName)
             artifactUrl = "${tmplName}-template/${version}/${archiveName}"
 
@@ -134,7 +134,7 @@ tasks.addRule("Pattern: publish#<proj>") { String taskName ->
 /**
  * Publishes all the project template zip archives.
  */
-task publishTemplates(dependsOn: templateDirs.collect { project.tasks["publish#${it.name}"] })
+task publishTemplates(dependsOn: templateDirs.collect { project.tasks["publish-${it.name}"] })
 
 task wrapper(type: Wrapper) {
     gradleVersion = '1.5'


### PR DESCRIPTION
'#' is a glob operator for zsh users. I changed # to - for all the
task rules. We usually use camel cased names for our task rules so
I could switch it over to that if you think it's better.

Updated the documentation to match the new task names.
