### PR TITLE
Fixed bug caching templates that don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The project templates are simply directory structures with whatever files in
 them that you want. Ultimately, the template project directories will be zipped
 up and stored on [BinTray](https://bintray.com/repo/browse/pledbrook/lazybones-templates).
 From there, lazybones downloads the zips on demand and caches them in a local
-user directory (currently ~/.groovy/lazybones-templates).
+user directory (currently ~/.lazybones/templates).
 
 If you want empty directories to form part of the project template, then simply
 add an empty .retain file to each one. When the template archive is created,
@@ -118,11 +118,11 @@ Finally, you can publish the whole shebang (unusual) with
     ./gradlew publishAll
 
 If you don't want to publish your template you can install it locally using the
-cacheTemplate task.
+installTemplate task.
 
-     ./gradlew cache-<templateName>
+     ./gradlew installTemplate-<templateName>
 
-This will install the template to ~/.groovy/lazybones so that you can use it without
+This will install the template to ~/.lazybones/templates so that you can use it without
 moving it to bintray first.
 
 And that's it for the project templates.

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
 
 ext {
     templatesDir = new File(projectDir, "src/templates")
-    cacheDir = new File(System.getProperty('user.home'), ".groovy/lazybones-templates")
+    installDir = new File(System.getProperty('user.home'), ".lazybones/templates")
 }
 
 sourceSets {
@@ -104,10 +104,10 @@ def templateDirs = templatesDir.listFiles({ f -> f.directory} as FileFilter)
 task packageTemplates(dependsOn: templateDirs.collect { project.tasks["packageTemplate-${it.name}"] })
 
 /**
- * Generates tasks to cache individual project templates so they can be used without bintray.
+ * Generates tasks to install individual project templates so they can be used without bintray.
  */
-tasks.addRule("Pattern: cacheTemplate-<proj>") { String taskName ->
-    def m = taskName =~ /cacheTemplate-(\S+)/
+tasks.addRule("Pattern: installTemplate-<proj>") { String taskName ->
+    def m = taskName =~ /installTemplate-(\S+)/
     if (m) {
         def archiveDetails = buildArchiveDetails(m[0][1])
         if (!archiveDetails) return
@@ -115,12 +115,12 @@ tasks.addRule("Pattern: cacheTemplate-<proj>") { String taskName ->
         task(taskName, type:Copy, dependsOn: "packageTemplate-$archiveDetails.templateName") {
             from "${buildDir}/${archiveDetails.archiveName}"
             rename { String fileName -> fileName.replace('-template', '') }
-            into "${cacheDir}"
+            into "${installDir}"
         }
     }
 }
 
-task cacheTemplates(dependsOn: templateDirs.collect { project.tasks["cacheTemplate-${it.name}"] })
+task installTemplates(dependsOn: templateDirs.collect { project.tasks["installTemplate-${it.name}"] })
 
 /**
  * Generates tasks to publish individual project template archives to BinTray.

--- a/src/main/groovy/uk/co/cacoethes/lazybones/LazyBonesMain.groovy
+++ b/src/main/groovy/uk/co/cacoethes/lazybones/LazyBonesMain.groovy
@@ -6,7 +6,7 @@ import uk.co.cacoethes.util.ArchiveMethods
 class LazyBonesMain {
 
     static final String templatesBaseUrl = "http://dl.bintray.com/v1/content/pledbrook/lazybones-templates"
-    static final File cacheDir = new File(System.getProperty('user.home'), ".groovy/lazybones-templates")
+    static final File installDir = new File(System.getProperty('user.home'), ".lazybones/templates")
 
     static void main(String[] args) {
         String cmd
@@ -156,11 +156,11 @@ USAGE: info <template>
 
     private static File fetchTemplate(String name, String version) {
         // Does it exist in the cache? If not, pull it from BinTray.
-        def packageFile = new File(cacheDir, "${name}-${version}.zip")
+        def packageFile = new File(installDir, "${name}-${version}.zip")
 
 
         if (!packageFile.exists()) {
-            cacheDir.mkdirs()
+            installDir.mkdirs()
             String externalUrl = templatesBaseUrl + "/${name}-template-${version}.zip"
             try {
                 packageFile.withOutputStream { OutputStream out ->


### PR DESCRIPTION
If you try to use lazybones with a template that doesn't exist
in the cache or bintray, it creates a 0 byte file in the cache.
I added some exception handling and an error message back to the
user to handle this.
