### PR TITLE
Fixing creating projects from a local template

### DIFF
--- a/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/commands/CreateCommand.groovy
+++ b/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/commands/CreateCommand.groovy
@@ -64,16 +64,17 @@ USAGE: create <template> <version>? <dir>
             }
         }
 
-        if (!pkgInfo) {
-            log.severe "Cannot find a template named '${packageName}'. Project has not been created."
-            return 1
-        }
-
         File targetDir
         String requestedVersion
         if (args.size() == 2) {
             // No version specified, so pull the latest from the package server.
             targetDir = args[1] as File
+
+            if (!pkgInfo) {
+                log.severe "Cannot find a template named '${packageName}'. Project has not been created."
+                return 1
+            }
+
             requestedVersion = pkgInfo.latestVersion
         }
         else {


### PR DESCRIPTION
If you use the `installTemplate` gradle task for doing local template development, you couldn't create a project from that template because it could try to grab the project meta data from bintray. When it didn't exist, an exception was thrown.

I just made this error only happen in the situation where the user doesn't specify a version and you need the template meta data to find the most recent version.
