### PR TITLE
Fix exception from out of date ratpack template

### DIFF
--- a/lazybones-templates/templates/ratpack/src/ratpack/ratpack.groovy
+++ b/lazybones-templates/templates/ratpack/src/ratpack/ratpack.groovy
@@ -1,11 +1,10 @@
-import org.ratpackframework.groovy.templating.TemplateRenderer
-
 import static org.ratpackframework.groovy.RatpackScript.ratpack
+import static org.ratpackframework.groovy.Template.groovyTemplate
 
 ratpack {
     handlers {
         get {
-            get(TemplateRenderer).render "index.html", title: "My Ratpack App"
+            render groovyTemplate("index.html", title: "My Ratpack App")
         }
     }
 }


### PR DESCRIPTION
The previous script throws an exception when trying to run the Ratpack application.

org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
ratpack.groovy: 1: unable to resolve class org.ratpackframework.groovy.templating.TemplateRenderer
 @ line 1, column 1.
   import org.ratpackframework.groovy.templating.TemplateRenderer
   ^

1 error

```
at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:309)
```
