### PR TITLE
Public directory should be available as a handler

### DIFF
--- a/lazybones-templates/templates/ratpack/src/ratpack/ratpack.groovy
+++ b/lazybones-templates/templates/ratpack/src/ratpack/ratpack.groovy
@@ -6,5 +6,7 @@ ratpack {
         get {
             render groovyTemplate("index.html", title: "My Ratpack App")
         }
+        
+        assets "public"
     }
 }


### PR DESCRIPTION
Right now, the template doesn't have assets "public". But this should really be in there since files in the public directory are not visible in the web app.
