### PR TITLE
Add src/ratpack to distZip task

### DIFF
--- a/lazybones-templates/templates/ratpack-lite/build.gradle
+++ b/lazybones-templates/templates/ratpack-lite/build.gradle
@@ -21,3 +21,7 @@ dependencies {
 	// It is not part of the app runtime and is not shipped in the distribution.
 	springloaded "org.springsource.springloaded:springloaded-core:1.1.1"
 }
+
+applicationDistribution.from("src/ratpack") {
+    into "bin"
+}

--- a/lazybones-templates/templates/ratpack/build.gradle
+++ b/lazybones-templates/templates/ratpack/build.gradle
@@ -27,3 +27,7 @@ dependencies {
 task wrapper(type: Wrapper) {
     gradleVersion = "1.6"
 }
+
+applicationDistribution.from("src/ratpack") {
+    into "bin"
+}


### PR DESCRIPTION
When running the distZip Gradle task nothing in src/ratpack is included in the created zip file.

As I understand it only files in src/dist are included by default, this pull request explicitly includes src/ratpack.  I'm no Gradle expert so hopefully this is the best solution to the problem :)

See also the following Ratpack issue https://github.com/ratpack/ratpack/issues/180
