### PR TITLE
remove drone.io build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ contribute templates by sending pull requests to this GitHub project or publishi
 the packages to the relevant [Bintray repository](https://bintray.com/repo/browse/pledbrook/lazybones-templates)
 (more info available below).
 
-[![Build Status](https://drone.io/github.com/pledbrook/lazybones/status.png)](https://drone.io/github.com/pledbrook/lazybones/latest)
-
 Developers
 ----------
 


### PR DESCRIPTION
This pull request removes the drone.io build status img, since the functional tests that need git will always fail.
