### PR TITLE
Add support for Handlebars templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,8 @@ The `${}` expressions are executed as Groovy expressions and they have access
 to any variables in the parameter map passed to `processTemplates()`. Scriptlets,
 i.e. code inside `<% %>` delimiters, allow for more complex logic.
 
+Alternatively templates can be written using [Mustache templates](http://mustache.github.io/mustache.5.html).
+This requires switching the template engine in `lazybones.groovy`:
+
+    import uk.co.cacoethes.lazybones.handlebars.HandlebarsTemplateEngine
+    setTemplateEngine(new HandlebarsTemplateEngine())

--- a/lazybones-app/app.gradle
+++ b/lazybones-app/app.gradle
@@ -52,7 +52,8 @@ dependencies {
             "org.codehaus.groovy:groovy-templates:${groovyVersion}",
             "org.apache.commons:commons-compress:1.5",
             "com.github.groovy-wslite:groovy-wslite:0.7.2",
-            "net.sf.jopt-simple:jopt-simple:4.4"
+            "net.sf.jopt-simple:jopt-simple:4.4",
+            "com.github.jknack:handlebars:1.2.1"
 
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
 

--- a/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/LazybonesScript.groovy
+++ b/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/LazybonesScript.groovy
@@ -2,6 +2,7 @@ package uk.co.cacoethes.lazybones
 
 import groovy.io.FileType
 import groovy.text.SimpleTemplateEngine
+import groovy.text.TemplateEngine
 import groovy.util.logging.Log
 import org.apache.commons.io.FilenameUtils
 import uk.co.cacoethes.util.AntPathMatcher
@@ -37,6 +38,8 @@ class LazybonesScript extends Script {
     Reader reader = new InputStreamReader(System.in)
 
     File scmExclusionsFile
+
+    TemplateEngine templateEngine = new SimpleTemplateEngine()
 
     /**
      * Declares the list of file patterns that should be excluded from SCM.
@@ -157,9 +160,8 @@ class LazybonesScript extends Script {
         }
         log.info "Filtering file $file"
 
-        def engine = new SimpleTemplateEngine()
         def reader = file.newReader(fileEncoding)
-        def template = engine.createTemplate(reader).make(properties)
+        def template = templateEngine.createTemplate(reader).make(properties)
         def out = new FileOutputStream(file)
         Writer writer = new OutputStreamWriter(out, fileEncoding)
         template.writeTo(writer)

--- a/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/handlebars/HandlebarsTemplate.groovy
+++ b/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/handlebars/HandlebarsTemplate.groovy
@@ -1,0 +1,26 @@
+package uk.co.cacoethes.lazybones.handlebars
+
+import groovy.text.Template
+
+class HandlebarsTemplate implements Template {
+
+    private final nativeTemplate
+
+    HandlebarsTemplate(final com.github.jknack.handlebars.Template nativeTemplate) {
+        this.nativeTemplate = nativeTemplate
+    }
+
+    @Override
+    Writable make() {
+        make null
+    }
+
+    @Override
+    Writable make(final Map binding) {
+        { Writer destination ->
+            nativeTemplate.apply(binding, destination)
+            destination.flush()
+            destination
+        } as Writable
+    }
+}

--- a/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/handlebars/HandlebarsTemplateEngine.groovy
+++ b/lazybones-app/src/main/groovy/uk/co/cacoethes/lazybones/handlebars/HandlebarsTemplateEngine.groovy
@@ -1,0 +1,22 @@
+package uk.co.cacoethes.lazybones.handlebars
+
+import com.github.jknack.handlebars.Handlebars
+import groovy.text.Template
+import groovy.text.TemplateEngine
+import org.codehaus.groovy.control.CompilationFailedException
+
+/**
+ * Implementation of {@code groovy.text.TemplateEngine} for Handlebars
+ *
+ * @author andyjduncan
+ */
+class HandlebarsTemplateEngine extends TemplateEngine {
+
+    def handlebars = new Handlebars()
+
+    @Override
+    Template createTemplate(Reader reader) throws CompilationFailedException, ClassNotFoundException, IOException {
+        def nativeTemplate = handlebars.compileInline(reader.text)
+        new HandlebarsTemplate(nativeTemplate)
+    }
+}

--- a/lazybones-app/src/test/groovy/uk/co/cacoethes/lazybones/LazybonesScriptSpec.groovy
+++ b/lazybones-app/src/test/groovy/uk/co/cacoethes/lazybones/LazybonesScriptSpec.groovy
@@ -1,9 +1,12 @@
 package uk.co.cacoethes.lazybones
 
+import groovy.text.SimpleTemplateEngine
+import groovy.text.TemplateEngine
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import uk.co.cacoethes.lazybones.handlebars.HandlebarsTemplateEngine
 
 import static uk.co.cacoethes.lazybones.LazybonesScript.DEFAULT_ENCODING
 
@@ -134,6 +137,29 @@ class LazybonesScriptSpec extends Specification {
 
         then:
         "bar" == response
+    }
+
+    void "default template engine is SimpleTemplateEngine"() {
+        expect:
+        SimpleTemplateEngine == new LazybonesScript().templateEngine.class
+    }
+
+    void "can use mustache templates"() {
+        given:
+        def mustacheFile = testFolder.newFile('mustache')
+        mustacheFile.write('hello {{foo}} and {{bar}}')
+        def script = createScript('''
+import uk.co.cacoethes.lazybones.handlebars.HandlebarsTemplateEngine
+setTemplateEngine(new HandlebarsTemplateEngine())
+processTemplates('mustache', [foo: "bar", bar: "bam"])
+''')
+        script.setTargetDir(testFolder.root.path)
+
+        when:
+        script.run()
+
+        then:
+        "hello bar and bam" == mustacheFile.text
     }
 
     LazybonesScript createScript(String text) {

--- a/lazybones-app/src/test/groovy/uk/co/cacoethes/lazybones/handlebars/HandlebarsTemplateSpec.groovy
+++ b/lazybones-app/src/test/groovy/uk/co/cacoethes/lazybones/handlebars/HandlebarsTemplateSpec.groovy
@@ -1,0 +1,59 @@
+package uk.co.cacoethes.lazybones.handlebars
+
+import groovy.text.Template
+import spock.lang.Specification
+
+class HandlebarsTemplateSpec extends Specification {
+
+    Template handlebarsTemplate
+
+    Map binding
+
+    def templated
+
+    void "renders a empty template"() {
+        when:
+        apply_template ''
+
+        then:
+        got_templated ''
+    }
+
+    void "renders a simple text template"() {
+        when:
+        apply_template 'Hello'
+
+        then:
+        got_templated 'Hello'
+    }
+
+    void "applies a binding to a template"() {
+        when:
+        apply_template 'Hello {{this.message}}' with_binding message:'there'
+
+        then:
+        got_templated 'Hello there'
+    }
+
+    def apply_template(template) {
+        def templateReader = new StringReader(template)
+        def engine = new HandlebarsTemplateEngine()
+        handlebarsTemplate = engine.createTemplate(templateReader)
+        this
+    }
+
+    void with_binding(Map binding) {
+        this.binding = binding
+    }
+
+    void got_templated(expectation) {
+        def writeDestination = new StringWriter()
+        if (binding) {
+            handlebarsTemplate.make(binding).writeTo(writeDestination)
+        } else {
+            handlebarsTemplate.make().writeTo(writeDestination)
+        }
+        templated = writeDestination.toString()
+        assert templated == expectation
+    }
+}


### PR DESCRIPTION
Add an implementation of `TemplateEngine` to support templates written
using Handlebars Mustache markup as discussed in issue #52. Add a
`templateEngine` variable to allow template scripts to choose the
alternative engine. Default is `SimpleTemplateEngine`.
