### PR TITLE
Minor improvements for name conversion

### DIFF
--- a/lazybones-app/src/main/groovy/uk/co/cacoethes/util/Naming.groovy
+++ b/lazybones-app/src/main/groovy/uk/co/cacoethes/util/Naming.groovy
@@ -87,7 +87,7 @@ class Naming {
         m.appendTail out
 
         out.replace(0, 1, name[0].toUpperCase())
-        return out.toString()
+        return out.toString().replace('.', '')
     }
 
     /**

--- a/lazybones-app/src/test/groovy/uk/co/cacoethes/util/NamingSpec.groovy
+++ b/lazybones-app/src/test/groovy/uk/co/cacoethes/util/NamingSpec.groovy
@@ -36,6 +36,7 @@ class NamingSpec extends Specification {
         HYPHENATED  |  CAMEL_CASE   |  "a-bee-cee-d"      |  "ABeeCeeD"
         HYPHENATED  |  CAMEL_CASE   |  "AA"               |  "AA"
         HYPHENATED  |  CAMEL_CASE   |  "aa-20-bb"         |  "Aa20Bb"
+        HYPHENATED  |  CAMEL_CASE   |  "aa-2.0-bb"        |  "Aa20Bb"
         PROPERTY    |  CAMEL_CASE   |  "abc"              |  "Abc"
         PROPERTY    |  CAMEL_CASE   |  "johnDoe"          |  "JohnDoe"
         PROPERTY    |  CAMEL_CASE   |  "aBeeCeeD"         |  "ABeeCeeD"


### PR DESCRIPTION
Hello,

I have suggestions for two changes in the Naming class for conversion of hyphenated names to camelcase. If there are numbers in the name the conversion result is not as expected in my view. The change consists of two simple commits you may apply each of them only one or neither of them if you like.
