### PR TITLE
Add info to README.md mentioning relationship to Maven archetypes and Ye...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ contribute templates by sending pull requests to this GitHub project or publishi
 the packages to the relevant [Bintray repository](https://bintray.com/repo/browse/pledbrook/lazybones-templates)
 (more info available below).
 
+The concept of LazyBones is very similar to what Maven does with archetypes, and what [Yeoman](http://yeoman.io/) does for web
+applications. Lazybones is more similar to Yeoman, in that Lazybones sub-templates can integrate templated features
+into an existing project, similar to how Yeoman can add useful parts to an existing project.
+
 [![Build Status](https://travis-ci.org/pledbrook/lazybones.svg?branch=master)](https://travis-ci.org/pledbrook/lazybones)
 
 ## Developers


### PR DESCRIPTION
...oman

It's helpful to add information to the overview that mentions how this tool is similar to other tools in related domains.  In particular, the Lazybones project does something very similar to what Maven does with archetypes, and what the Yeoman project does for JavaScript-based web applications. The added paragraph hopefully puts some light on that.