### PR TITLE
Updated README for plugin name and version

### DIFF
--- a/lazybones-gradle-plugin/README.md
+++ b/lazybones-gradle-plugin/README.md
@@ -23,11 +23,11 @@ to set it up manually in the `buildscript` section of your build file:
         }
     
         dependencies {
-            classpath "uk.co.cacoethes:lazybones-gradle:1.1"
+            classpath "uk.co.cacoethes:lazybones-gradle:1.2.3"
         }
     }
 
-	apply plugin: "lazybones-templates"
+	apply plugin: "uk.co.cacoethes.lazybones-templates"
 	...
 
 ## Conventions & required configuration


### PR DESCRIPTION
The "name" of the plugin changed from `"lazybones-templates"` to `"uk.co.cacoethes.lazybones-templates"` but the README was referring to the old name.