### PR TITLE
Corrected doc about proxy setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,11 +291,11 @@ proxy, you only need to add the following to your Lazybones configuration:
     systemProp {
         http {
             proxyHost = "localhost"
-            proxyPort = 8181
+            proxyPort = "8181"
         }
         https {
             proxyHost = "localhost"
-            proxyPort = 8181
+            proxyPort = "8181"
         }
     }
     


### PR DESCRIPTION
`proxyPort = 8181` fails. `proxyPort` needs to be a String to make lazybones work properly with a HTTP proxy.

    Exception in thread "main" uk.co.cacoethes.lazybones.config.MultipleInvalidSettingsException: The following configuration settings are invalid: systemProp.http.proxyPort, systemProp.https.proxyPort
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:77)
	at org.codehaus.groovy.reflection.CachedConstructor.doConstructorInvoke(CachedConstructor.java:71)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite.callConstructor(ConstructorSite.java:42)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:182)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:190)
	at uk.co.cacoethes.lazybones.config.Configuration.<init>(Configuration.groovy:100)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:77)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:102)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:182)
	at uk.co.cacoethes.lazybones.config.Configuration.initConfiguration(Configuration.groovy:323)
	at uk.co.cacoethes.lazybones.config.Configuration$initConfiguration.callStatic(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:53)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:157)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:173)
	at uk.co.cacoethes.lazybones.config.Configuration.initConfiguration(Configuration.groovy:308)
	at uk.co.cacoethes.lazybones.LazybonesMain.main(LazybonesMain.groovy:36)


