### PR TITLE
Update lazybones-gradle version to 1.2.4 to support 'vcsUrl', …

### DIFF
--- a/lazybones-templates/templates/lazybones-project/build.gradle
+++ b/lazybones-templates/templates/lazybones-project/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "uk.co.cacoethes:lazybones-gradle:1.2"
+        classpath "uk.co.cacoethes:lazybones-gradle:1.2.4"
     }
 }
 
@@ -25,4 +25,10 @@ lazybones {
     // and `project.bintrayApiKey` respectively.
     repositoryUsername = "your_bintray_username"
     repositoryApiKey = "your_bintray_api_key"
+
+    // Required for Bintray open source hosting, substitute you license and
+    // vcsUrl:
+
+    // licenses = ["Apache-2.0"]
+    // vcsUrl = "https://github.com/yourRepoName"
 }


### PR DESCRIPTION
... add hint for licenses and vcsUrl for binary support.

I was attempting to publish a template to a new open source bintray and things were exploding. Seems the lazybones templates template had an older dependency declared for the lazybones-gradle plugin (1.2) causing stacktrace: 

    * Exception is:
org.gradle.api.GradleScriptException: A problem occurred evaluating root project 'my-lzb-templates'.
    ...
    Caused by: groovy.lang.MissingPropertyException: No such property: vcsUrl for class: uk.co.cacoethes.gradle.lazybones.LazybonesConventions_Decorated

This seemed to be fixed by bumping to 1.2.4 (found on your bintray: http://dl.bintray.com/pledbrook/plugins/uk/co/cacoethes/lazybones-gradle/).

Also added a hint for those that didn't catch the line in the wiki about the vcsUrl and licenses being required.